### PR TITLE
Fix force unwraps

### DIFF
--- a/Sources/pcb2photon/Converter.swift
+++ b/Sources/pcb2photon/Converter.swift
@@ -98,7 +98,10 @@ class Converter{
         while i < argCount {
             let argument = CommandLine.arguments[i]
             if argument.first == "-"{
-                let (option, value) = getOption(String(argument.dropFirst().first!))
+                guard let optionChar = argument.dropFirst().first else {
+                    throw OptionError.invalidOption(option: argument)
+                }
+                let (option, value) = getOption(String(optionChar))
                 switch option {
                 case .threshold:
                     guard i+1 < argCount, let arg :Float = Float(CommandLine.arguments[i+1]), arg > 0, arg < 1 else{

--- a/Sources/pcb2photon/ImageFileDecoders.swift
+++ b/Sources/pcb2photon/ImageFileDecoders.swift
@@ -33,7 +33,7 @@ class SGLImageConverter: ImageFileConverter {
         self.loader = SGLImageLoader(fromFile: fileURL.path)
         config = opt
         guard loader.error == nil else {
-            throw ConvertError.internalConverterError(error : loader.error!)
+            throw ConvertError.internalConverterError(error: loader.error ?? "Unknown error")
         }
     }
     

--- a/Sources/pcb2photon/PhotonFileHandler.swift
+++ b/Sources/pcb2photon/PhotonFileHandler.swift
@@ -47,8 +47,12 @@ extension UInt32{
 }
 
 class PhotonFile {
-    private var templatePhotonFile1440x2560:Data {
-        return try! Data(contentsOf: URL(fileURLWithPath: Bundle.main.path(forResource: "template", ofType: "photon") ?? ""))
+    private var templatePhotonFile1440x2560: Data {
+        guard let path = Bundle.main.path(forResource: "template", ofType: "photon"),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return Data()
+        }
+        return data
     }
     private var header:Data{
         get{


### PR DESCRIPTION
## Summary
- handle loader error safely when converting images
- avoid force unwrap when parsing CLI options
- load template photon file safely

## Testing
- `swift build`
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbf4ff04832cb367631d28e7e7e2