### PR TITLE
Encapsulate photon constants

### DIFF
--- a/Sources/pcb2photon/ImageFileDecoders.swift
+++ b/Sources/pcb2photon/ImageFileDecoders.swift
@@ -24,8 +24,10 @@ protocol ImageFileConverter {
 
 class SGLImageConverter: ImageFileConverter {
     let config : ConversionOptions
-    let outImageWidth = 1440
-    let outImageHeight = 2560
+    /// Width of the generated photon image in pixels.
+    let outImageWidth = Int(PhotonConstants.imageWidth)
+    /// Height of the generated photon image in pixels.
+    let outImageHeight = Int(PhotonConstants.imageHeight)
     
     var loader:SGLImageLoader
     

--- a/Sources/pcb2photon/PhotonConstants.swift
+++ b/Sources/pcb2photon/PhotonConstants.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Common constants used throughout the photon file generation.
+enum PhotonConstants {
+    /// Default photon image width in pixels.
+    static let imageWidth: UInt32 = 1440
+    /// Default photon image height in pixels.
+    static let imageHeight: UInt32 = 2560
+
+    /// Default PCB thickness in millimeters.
+    static let pcbThickness: Float = 1.6
+
+    /// Default exposure time for a layer in seconds.
+    static let exposure: Float = 15.0
+
+    /// Default printer volume sizes in millimeters.
+    static let printSizeX: Float = 68.04
+    static let printSizeY: Float = 120.96
+    static let printSizeZ: Float = 5.0
+
+    /// Additional header configuration.
+    static let bottomExposureTime: Float = 0.0
+    static let offTime: Float = 0.0
+    static let numberOfBottomLayers: UInt32 = 0
+    static let numberOfLayers: UInt32 = 1
+
+    /// Prefix bytes for photon headers.
+    static let headerMagic: [UInt8] = [0x19,0x00,0xFD,0x12,0x01,0x00,0x00,0x00]
+
+    /// Generic 8 and 12 byte padding blocks.
+    static let padding8 = [UInt8](repeating: 0x00, count: 8)
+    static let padding12 = [UInt8](repeating: 0x00, count: 12)
+
+    /// Blocks of bytes with unknown meaning kept for completeness.
+    static let unknownBlock1: [UInt8] = [0x6C,0x00,0x00,0x00,0xAC,0xF0,0x00,0x00]
+    static let unknownBlock2: [UInt8] = [0xD0,0xE0,0x00,0x00,0x00,0x00,0x00,0x00]
+    static let unknownBlock3: [UInt8] = [0x01,0x00,0x00,0x00]
+    static let unknownBlock4: [UInt8] = [0x33,0x04,0x00,0x00,0xE6,0x00,0x00,0x00]
+    static let unknownBlock5: [UInt8] = [0x8C,0x00,0x00,0x00,0x44,0xE0,0x00,0x00]
+}

--- a/Sources/pcb2photon/PhotonFileHandler.swift
+++ b/Sources/pcb2photon/PhotonFileHandler.swift
@@ -52,28 +52,28 @@ class PhotonFile {
     }
     private var header:Data{
         get{
-            var sig:[UInt8] = [0x19,0x00,0xFD,0x12,0x01,0x00,0x00,0x00]
-            
-            let pcbThickness : Float        = 1.6 //mm
-            let exposure : Float            = 15.0 //seconds
-            
-            let printSizeX:Float = 68.04
-            let printSizeY:Float = 120.96
-            let printSizeZ:Float = 5
-            
-            let bottomExposureTime:Float = 0.0
-            let offTime:Float = 0.0
-            let numberOfBottomLayers:UInt32 = 0
-            let sizeX:UInt32 = 1440
-            let sizeY:UInt32 = 2560
-            
-            let numberOfLayers:UInt32 = 1
+            var sig:[UInt8] = PhotonConstants.headerMagic
+
+            let pcbThickness : Float        = PhotonConstants.pcbThickness
+            let exposure : Float            = PhotonConstants.exposure
+
+            let printSizeX:Float = PhotonConstants.printSizeX
+            let printSizeY:Float = PhotonConstants.printSizeY
+            let printSizeZ:Float = PhotonConstants.printSizeZ
+
+            let bottomExposureTime:Float = PhotonConstants.bottomExposureTime
+            let offTime:Float = PhotonConstants.offTime
+            let numberOfBottomLayers:UInt32 = PhotonConstants.numberOfBottomLayers
+            let sizeX:UInt32 = PhotonConstants.imageWidth
+            let sizeY:UInt32 = PhotonConstants.imageHeight
+
+            let numberOfLayers:UInt32 = PhotonConstants.numberOfLayers
             
             sig.append(contentsOf: printSizeX.asByteArray())
             sig.append(contentsOf: printSizeY.asByteArray())
             sig.append(contentsOf: printSizeZ.asByteArray())
             
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00]) // padding
+            sig.append(contentsOf: PhotonConstants.padding12)
             
             sig.append(contentsOf: pcbThickness.asByteArray())
             
@@ -88,23 +88,23 @@ class PhotonFile {
             sig.append(contentsOf: sizeX.asByteArray())
             sig.append(contentsOf: sizeY.asByteArray())
             
-            sig.append(contentsOf: [0x6C,0x00,0x00,0x00,0xAC,0xF0,0x00,0x00])
+            sig.append(contentsOf: PhotonConstants.unknownBlock1)
             
             sig.append(contentsOf: numberOfLayers.asByteArray())
             
 
-            sig.append(contentsOf: [0xD0,0xE0,0x00,0x00,0x00,0x00,0x00,0x00])
-            sig.append(contentsOf: [0x01,0x00,0x00,0x00])
+            sig.append(contentsOf: PhotonConstants.unknownBlock2)
+            sig.append(contentsOf: PhotonConstants.unknownBlock3)
             
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
+            sig.append(contentsOf: PhotonConstants.padding8) // padding
+            sig.append(contentsOf: PhotonConstants.padding8) // padding
+            sig.append(contentsOf: PhotonConstants.padding8) // padding
             
-            sig.append(contentsOf: [0x33,0x04,0x00,0x00,0xE6,0x00,0x00,0x00])
-            sig.append(contentsOf: [0x8C,0x00,0x00,0x00,0x44,0xE0,0x00,0x00])
+            sig.append(contentsOf: PhotonConstants.unknownBlock4)
+            sig.append(contentsOf: PhotonConstants.unknownBlock5)
             
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
-            sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
+            sig.append(contentsOf: PhotonConstants.padding8) // padding
+            sig.append(contentsOf: PhotonConstants.padding8) // padding
             
             return Data(bytes: sig)
         }


### PR DESCRIPTION
## Summary
- define `PhotonConstants` to group image dimensions and header bytes
- use new constants in `SGLImageConverter` and `PhotonFileHandler`

## Testing
- `swift build`
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bc3f6f50832caccfb0f0513eea65