### PR TITLE
Update to Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -13,8 +13,11 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
+        .executableTarget(
             name: "pcb2photon",
-            dependencies: ["SGLImage"]),
+            dependencies: [
+                .product(name: "SGLImage", package: "Image")
+            ]
+        ),
     ]
 )

--- a/Sources/pcb2photon/ImageFileDecoders.swift
+++ b/Sources/pcb2photon/ImageFileDecoders.swift
@@ -90,34 +90,34 @@ class SGLImageConverter: ImageFileConverter {
             }
             
         }
-        let imageData:Data = Data(bytes: buckets.map{$0.byte})
+        let imageData: Data = Data(buckets.map { $0.byte })
         var fileData:Data = PhotonFile().data()
         
         //Prepare and append imag array metadata
         var layerHeight = config.pcbThickness
-        let layerHeightData = Data(buffer: UnsafeBufferPointer(start: &layerHeight, count: 1))
+        let layerHeightData = withUnsafeBytes(of: &layerHeight) { Data($0) }
         fileData.append(layerHeightData)
         
         var expTime = config.exposure
-        let expTimeData = Data(buffer: UnsafeBufferPointer(start: &expTime, count: 1))
+        let expTimeData = withUnsafeBytes(of: &expTime) { Data($0) }
         fileData.append(expTimeData)
         
         var offTime = UInt32(0)
-        let offTimeData = Data(buffer: UnsafeBufferPointer(start: &offTime, count: 1))
+        let offTimeData = withUnsafeBytes(of: &offTime) { Data($0) }
         fileData.append(offTimeData)
         
-        var startPos = UInt32(fileData.count+24)
-        let startPosData = Data(buffer: UnsafeBufferPointer(start: &startPos, count: 1))
+        var startPos = UInt32(fileData.count + 24)
+        let startPosData = withUnsafeBytes(of: &startPos) { Data($0) }
         fileData.append(startPosData)
         
         var size = UInt32(imageData.count)
-        let sizeData = Data(buffer: UnsafeBufferPointer(start: &size, count: 1))
+        let sizeData = withUnsafeBytes(of: &size) { Data($0) }
         fileData.append(sizeData)
         
-        let padding = [UInt32(0),UInt32(0),UInt32(0),UInt32(0)]
-        padding.forEach{
+        let padding = [UInt32(0), UInt32(0), UInt32(0), UInt32(0)]
+        padding.forEach {
             var val = $0
-            let data = Data(buffer: UnsafeBufferPointer(start: &val, count: 1))
+            let data = withUnsafeBytes(of: &val) { Data($0) }
             fileData.append(data)
         }
         //Append image data

--- a/Sources/pcb2photon/PhotonFileHandler.swift
+++ b/Sources/pcb2photon/PhotonFileHandler.swift
@@ -9,10 +9,9 @@ import Foundation
 
 extension Float{
     var asData:Data{
-        get{
+        get {
             var value = self
-            let data = Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
-            return data
+            return withUnsafeBytes(of: &value) { Data($0) }
         }
     }
     func asByteArray() -> [UInt8] {
@@ -22,10 +21,9 @@ extension Float{
 
 extension UInt16{
     var asData:Data{
-        get{
+        get {
             var value = self
-            let data = Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
-            return data
+            return withUnsafeBytes(of: &value) { Data($0) }
         }
     }
     func asByteArray() -> [UInt8] {
@@ -35,10 +33,9 @@ extension UInt16{
 
 extension UInt32{
     var asData:Data{
-        get{
+        get {
             var value = self
-            let data = Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
-            return data
+            return withUnsafeBytes(of: &value) { Data($0) }
         }
     }
     func asByteArray() -> [UInt8] {
@@ -106,7 +103,7 @@ class PhotonFile {
             sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
             sig.append(contentsOf: [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]) // padding
             
-            return Data(bytes: sig)
+            return Data(sig)
         }
     }
     


### PR DESCRIPTION
## Summary
- update `Package.swift` to Swift 5.5 and use executableTarget
- rewrite unsafe buffer usage with `withUnsafeBytes`
- modernize `Data` initializers

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_6840ba20ec5c832c9d2910b4ff6c9cc3