### PR TITLE
Improve naming and add documentation

### DIFF
--- a/Sources/pcb2photon/ConsoleOutput.swift
+++ b/Sources/pcb2photon/ConsoleOutput.swift
@@ -1,5 +1,5 @@
 //
-//  ConsoleIO.swift
+//  ConsoleOutput.swift
 //  pcb2photon
 //
 //  Created by Leonardo Marques on 17.05.18.
@@ -14,7 +14,12 @@ enum OutputType {
     case standard
 }
 
-class ConsoleIO{
+/// Provides simple utilities for printing information to the console.
+class ConsoleOutput{
+    /// Writes a message to standard output or standard error.
+    /// - Parameters:
+    ///   - message: The text to display.
+    ///   - to:     Destination stream for the message.
     func writeMessage(_ message: String, to: OutputType = .standard) {
         switch to {
         case .standard:
@@ -23,6 +28,7 @@ class ConsoleIO{
             fputs("Error: \(message)\n", stderr)
         }
     }
+    /// Prints a short usage description for the tool.
     func printUsage() {
         let executableName = NSString(string: CommandLine.arguments[0]).lastPathComponent
         writeMessage("usage:")

--- a/Sources/pcb2photon/PhotonFileConverter.swift
+++ b/Sources/pcb2photon/PhotonFileConverter.swift
@@ -1,5 +1,5 @@
 //
-//  Converter.swift
+//  PhotonFileConverter.swift
 //  pcb2photon
 //
 //  Created by Leonardo Marques on 17.05.18.
@@ -9,6 +9,7 @@
 import Foundation
 import SGLImage
 
+/// Configuration options for the conversion process.
 struct ConversionOptions {
     //                              defaults:
     var threshold : Float           = 0.5
@@ -20,19 +21,27 @@ struct ConversionOptions {
     var exposure : Float            = 5.0 //seconds
 }
 
-class Converter{
-    let consoleIO : ConsoleIO           = ConsoleIO()
+/// Handles command line parsing and coordinates the conversion of image files
+/// into `.photon` files.
+class PhotonFileConverter{
+    /// Utility for printing information to the console.
+    let consoleIO : ConsoleOutput = ConsoleOutput()
+
+    /// Options that control the conversion process.
     var conversionOptions : ConversionOptions = ConversionOptions()
-    var filesToConvert : [String]       = []
+
+    /// List of input file paths to convert.
+    var filesToConvert : [String] = []
     
-    func staticMode() {
+    /// Executes the conversion using command line arguments.
+    func run() {
         do {
             try readParameters()
             
             let files = Array(zip(filesToConvert, conversionOptions.output))
             var allFiles = filesToConvert.map{return ($0, $0)}
             allFiles.replaceSubrange(0..<files.count, with: files)
-            try files.forEach{try convert($0,into: $1)}
+            try files.forEach { try convertImage($0, to: $1) }
             
         } catch OptionError.invalidValue(let option) {
             consoleIO.writeMessage("01 Invalid value for \(option).", to: .error)
@@ -56,14 +65,18 @@ class Converter{
         
     }
     
-    private func convert(_ fileName:String, into newFile:String?=nil) throws{
-        //Get file path
-        let fileURL:URL = try getPath(to: fileName)
+    /// Converts a single image file into a Photon file.
+    /// - Parameters:
+    ///   - fileName: Path to the image that will be converted.
+    ///   - newFile: Optional name for the output Photon file.
+    private func convertImage(_ fileName: String, to newFile: String? = nil) throws {
+        // Get file path
+        let fileURL: URL = try getPath(to: fileName)
         //Fetch file data
         //let fileData = try Data(contentsOf: fileURL)
         
         
-        let fileData = try SGLImageConverter(fileURL, options: conversionOptions).convert()
+        let fileData = try SwiftGLPhotonConverter(fileURL, options: conversionOptions).convert()
         
         if let newFileName:String = newFile {
             let pathURL = fileURL.deletingLastPathComponent()
@@ -77,7 +90,7 @@ class Converter{
     }
     
     //
-    private func fileDecoderFactory(_ file:Data) -> ImageFileConverter?{
+    private func fileDecoderFactory(_ file: Data) -> PhotonImageConverter? {
         return nil
     }
     

--- a/Sources/pcb2photon/PhotonFileHandler.swift
+++ b/Sources/pcb2photon/PhotonFileHandler.swift
@@ -46,6 +46,7 @@ extension UInt32{
     }
 }
 
+/// Utility for constructing Photon files from raw image data.
 class PhotonFile {
     private var templatePhotonFile1440x2560:Data {
         return try! Data(contentsOf: URL(fileURLWithPath: Bundle.main.path(forResource: "template", ofType: "photon") ?? ""))
@@ -110,8 +111,9 @@ class PhotonFile {
         }
     }
     
-    func data() -> Data{
-        var fileData:Data = self.header
+    /// Returns a complete Photon file combining the header with the template data.
+    func fileContent() -> Data {
+        var fileData: Data = self.header
         fileData.append(self.templatePhotonFile1440x2560)
         return fileData
     }

--- a/Sources/pcb2photon/main.swift
+++ b/Sources/pcb2photon/main.swift
@@ -9,12 +9,12 @@
 
 import Foundation
 
-let converter = Converter()
+let converter = PhotonFileConverter()
 
 if CommandLine.argc < 2 {
     //TODO: Handle interactive mode
 } else {
-    converter.staticMode()
+    converter.run()
 }
 
 

--- a/pcb2photon.xcodeproj/project.pbxproj
+++ b/pcb2photon.xcodeproj/project.pbxproj
@@ -18,8 +18,8 @@
 		OBJ_37 /* ImagePNG.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* ImagePNG.swift */; };
 		OBJ_38 /* Inflate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Inflate.swift */; };
 		OBJ_45 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Package.swift */; };
-		OBJ_51 /* ConsoleIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* ConsoleIO.swift */; };
-		OBJ_52 /* Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Converter.swift */; };
+               OBJ_51 /* ConsoleOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* ConsoleOutput.swift */; };
+               OBJ_52 /* PhotonFileConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* PhotonFileConverter.swift */; };
 		OBJ_53 /* ConverterUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* ConverterUtil.swift */; };
 		OBJ_54 /* ImageFileDecoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ImageFileDecoders.swift */; };
 		OBJ_55 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* main.swift */; };
@@ -61,7 +61,7 @@
 		22C91E2C20B5804700F45D5A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		22C91E2D20B5804800F45D5A /* activityDiagram.pltuml */ = {isa = PBXFileReference; lastKnownFileType = text; path = activityDiagram.pltuml; sourceTree = "<group>"; };
 		22C91E2E20B580F900F45D5A /* result.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = result.png; sourceTree = "<group>"; };
-		OBJ_10 /* Converter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Converter.swift; sourceTree = "<group>"; };
+               OBJ_10 /* PhotonFileConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotonFileConverter.swift; sourceTree = "<group>"; };
 		OBJ_11 /* ConverterUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConverterUtil.swift; sourceTree = "<group>"; };
 		OBJ_12 /* ImageFileDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileDecoders.swift; sourceTree = "<group>"; };
 		OBJ_13 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -73,7 +73,7 @@
 		OBJ_23 /* Inflate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inflate.swift; sourceTree = "<group>"; };
 		OBJ_24 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/reox/Documents/Git Repos/pcb2photon/.build/checkouts/Image.git--6271664722653506445/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* ConsoleIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleIO.swift; sourceTree = "<group>"; };
+               OBJ_9 /* ConsoleOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleOutput.swift; sourceTree = "<group>"; };
 		"SGLImage::SGLImage::Product" /* SGLImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SGLImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"pcb2photon::pcb2photon::Product" /* pcb2photon */ = {isa = PBXFileReference; lastKnownFileType = text; path = pcb2photon; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -181,8 +181,8 @@
 		OBJ_8 /* pcb2photon */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_9 /* ConsoleIO.swift */,
-				OBJ_10 /* Converter.swift */,
+                               OBJ_9 /* ConsoleOutput.swift */,
+                               OBJ_10 /* PhotonFileConverter.swift */,
 				OBJ_11 /* ConverterUtil.swift */,
 				OBJ_12 /* ImageFileDecoders.swift */,
 				OBJ_13 /* main.swift */,
@@ -311,8 +311,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_51 /* ConsoleIO.swift in Sources */,
-				OBJ_52 /* Converter.swift in Sources */,
+                               OBJ_51 /* ConsoleOutput.swift in Sources */,
+                               OBJ_52 /* PhotonFileConverter.swift in Sources */,
 				22C91E2B20B4550400F45D5A /* PhotonFileHandler.swift in Sources */,
 				OBJ_53 /* ConverterUtil.swift in Sources */,
 				OBJ_54 /* ImageFileDecoders.swift in Sources */,


### PR DESCRIPTION
## Summary
- rename ConsoleIO to ConsoleOutput and document it
- rename Converter to PhotonFileConverter and document it
- rename SGLImageConverter to SwiftGLPhotonConverter and related types
- rename PhotonFile.data() to `fileContent()` and document PhotonFile
- update Xcode project references

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_6840bc1c1a90832c94505ab58844f06a